### PR TITLE
Fix static field offset bug

### DIFF
--- a/runtime/native/unsafe.cpp
+++ b/runtime/native/unsafe.cpp
@@ -307,15 +307,17 @@ Java_sun_misc_Unsafe_objectFieldOffset(JNIEnv *env, jobject unsafeObj, jobject f
     if (slot >= 0) {
         return info->fields[slot].offset;
     } else {
-        // return ((jlong) info->static_fields[-slot-1].ptr) - ((jlong) fieldObj);
-        return ((jlong) info->static_fields[-slot-1].ptr);
+         return ((jlong) info->static_fields[-slot-1].ptr) - ((jlong) fieldObj);
     }
 }
 
 jobject
-Java_sun_misc_Unsafe_staticFieldBase(JNIEnv *env, jobject, jobject) {
+Java_sun_misc_Unsafe_staticFieldBase(JNIEnv *env, jobject unsafeObj, jobject fieldObj) {
     // UnsafeUnimplemented("Java_sun_misc_Unsafe_staticFieldBase");
-    return NULL;
+    // WARNING: Assume the address of static field is within 32bit offset range 
+    //          of the fieldObj since sun.misc.Unsafe.fieldOffset(field) cast
+    //          the offset from long to int.
+    return fieldObj;
 }
 
 jboolean


### PR DESCRIPTION
Previously we used the absolute address to access field offset. However,
the address was larger than 32bit and the method sun.misc.Unsafe.fieldOffset(field)
truncated it to 32 bit. When a static variable had address larger than 32 bit, it would lead to a segfault.

Now, we use the relative address instead, and the base pointer is the fieldObj. We compute the offset in `Java_sun_misc_Unsafe_objectFieldOffset` and return `fieldObj` in `Java_sun_misc_Unsafe_staticFieldBase`. We make an assumption that the static variable is within 32bit range of the fieldObj. It should be safe since fieldObj is allocated on the heap and static variable is on the .bss section.