### PR TITLE
Exception resume fix

### DIFF
--- a/compiler/src/jlang/extension/JLangTryExt.java
+++ b/compiler/src/jlang/extension/JLangTryExt.java
@@ -250,7 +250,11 @@ public class JLangTryExt extends JLangExt {
                 frame.buildFinallyBlockBranchingTo(rethrowBlock);
             } else {
                 // We did not catch the exception. Resume unwinding.
-                LLVMBuildResume(v.builder, lpadCatchRes);
+                // LLVMBuildResume(v.builder, lpadCatchRes);
+                LLVMValueRef resumeFun = v.utils.getFunction(Constants.RESUME_UNWIND_EXCEPTION,
+                    v.utils.functionType(LLVMVoidTypeInContext(v.context), v.utils.i8Ptr()));
+                v.utils.buildProcCall(resumeFun, catchExn);
+                LLVMBuildUnreachable(v.builder);
             }
         }
 

--- a/compiler/src/jlang/util/Constants.java
+++ b/compiler/src/jlang/util/Constants.java
@@ -31,6 +31,7 @@ public class Constants {
     public static final String CREATE_EXCEPTION = "createUnwindException";
     public static final String THROW_EXCEPTION = "throwUnwindException";
     public static final String EXTRACT_EXCEPTION = "extractJavaExceptionObject";
+    public static final String RESUME_UNWIND_EXCEPTION = "_Unwind_Resume";
 
     public static final Set<String> NON_INVOKE_FUNCTIONS = new HashSet<>(CollectionUtil.list(
             CALLOC, CREATE_EXCEPTION, EXTRACT_EXCEPTION

--- a/tests/isolated/ExceptionsNested.java
+++ b/tests/isolated/ExceptionsNested.java
@@ -1,0 +1,22 @@
+class ExceptionsNested {
+    public static void main(String[] args) {
+        try {
+            catchesRuntimeExn();
+            System.out.println("Should not print");
+        } catch (Exception e) {
+            System.out.println("Caught exception");
+        }
+    }
+
+    public static void catchesRuntimeExn() throws Exception {
+        try {
+            throwsExn();
+        } catch (RuntimeException e) {
+            System.out.println("Caught runtime exception");
+        }
+    }
+
+    public static void throwsExn() throws Exception {
+        throw new Exception();
+    }
+}


### PR DESCRIPTION
It seems like whatever compiles the .ll files ignores the resume block and doesn't insert the proper call the unwind.h library. This makes the explicit call to the correct function.