### PR TITLE
[#21] Add travis support for PR/CI testing of JLang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,90 @@
+language: java
+jdk:
+  - oraclejdk8
+
+cache:
+  directories:
+    - /usr/local/Homebrew
+
+env: BOEHM_VERSION=7.6.4
+
+addons:
+  homebrew:
+    packages:
+    - llvm@5
+    - git-lfs
+    - ant@1.9
+    - libatomic_ops
+    update: true
+  apt:
+    sources:
+      - llvm-toolchain-trusty-5.0
+      - llvm-toolchain-trusty-6.0
+      - sourceline: 'ppa:ubuntu-toolchain-r/test'
+      - sourceline: 'ppa:git-core/ppa'
+    packages:
+      - clang-5.0 llvm-5.0 llvm-5.0-dev libllvm5.0 libstdc++6 libclang-common-5.0-dev libclang1-5.0 llvm-5.0-runtime libllvm5.0 libstdc++6 libllvm5.0
+      - libatomic-ops-dev
+
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+      osx_image: xcode9.3
+
+    - os: linux
+      dist: precise
+
+install: 
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      # Install git lfs
+      curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+      sudo apt-get install git-lfs
+
+      # Install ant 1.9.14
+      wget https://www-us.apache.org/dist//ant/binaries/apache-ant-1.9.14-bin.tar.gz
+      sudo tar -xzf apache-ant-1.9.14-bin.tar.gz
+      export PATH=$(pwd)/apache-ant-1.9.14/bin:${PATH}
+
+      # Download Boehm GC
+      wget http://www.hboehm.info/gc/gc_source/gc-${BOEHM_VERSION}.tar.gz
+      sudo tar -xzf gc-${BOEHM_VERSION}.tar.gz
+    else
+      # Add llvm 5 to the path
+      export PATH="/usr/local/opt/llvm@5/bin:$PATH"
+
+      #Add ant 1.9 to the path
+      export PATH="/usr/local/opt/ant@1.9/bin:$PATH"
+
+      #Download Boehm GC
+      curl -OL http://www.hboehm.info/gc/gc_source/gc-${BOEHM_VERSION}.tar.gz
+      sudo tar -xzf gc-${BOEHM_VERSION}.tar.gz
+    fi
+
+  # Install Boehm GC
+  - sudo tar -xzf gc-${BOEHM_VERSION}.tar.gz
+  - cd gc-${BOEHM_VERSION}
+  - sudo ./configure 
+  - sudo make 
+  - sudo make install
+
+before_script:
+  - cd ${TRAVIS_BUILD_DIR}
+  - git lfs pull
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      export JDK7=/usr/lib/jvm/java-7-oracle
+      export CLANG_VERSION=5.0
+    else
+      export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
+      export JDK7=$(/usr/libexec/java_home -v 1.8)
+      export JDK=jdk
+    fi
+
+script:
+  - |
+      make
+      if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+        make tests
+      fi

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,13 @@ POLYGLOT := lib/polyglot/
 JAVACPP_PRESETS := lib/javacpp-presets/
 SUBMODULES := $(addsuffix .git,$(POLYGLOT) $(JAVACPP_PRESETS))
 
+# Setup variables for travis CI
+ifdef TRAVIS
+ADDITIONAL_JLANGC_OPTIONS:=-compiler-classpath $(realpath lib/llvm-linux-x86_64-Ubuntu12.04.jar)
+endif
+
 # JLang
-export PLC := $(realpath bin/jlangc)
+export PLC := $(realpath bin/jlangc) $(ADDITIONAL_JLANGC_OPTIONS)
 
 # Hack to allow dependency on PolyLLVM source.
 export PLC_SRC := $(realpath $(shell find compiler/src -name "*.java"))

--- a/bin/jlangc
+++ b/bin/jlangc
@@ -28,6 +28,7 @@ fixpath() {
 }
 
 extra_cp=
+extra_compiler_cp=
 args=
 vmargs=
 java=java
@@ -47,6 +48,11 @@ while true; do
             extra_cp="$extra_cp:$1"
             shift
             ;;
+        -compiler-classpath)
+            shift
+            extra_compiler_cp="$extra_compiler_cp:$1"
+            shift
+            ;;        
         -j)
             shift
             vmargs="$vmargs '$1'"
@@ -68,7 +74,7 @@ while true; do
     esac
 done
 
-compiler_classpath="$dir/compiler/classes:$dir/lib/polyglot/lib/java_cup.jar:$dir/lib/polyglot/lib/polyglot.jar:$dir/lib/llvm.jar:$dir/lib/javacpp.jar:$dir/lib/llvm-macosx-x86_64.jar:$dir/lib/llvm-linux-x86_64.jar"
+compiler_classpath="$dir/compiler/classes:$dir/lib/polyglot/lib/java_cup.jar:$dir/lib/polyglot/lib/polyglot.jar:$dir/lib/llvm.jar:$dir/lib/javacpp.jar:$extra_compiler_cp:$dir/lib/llvm-macosx-x86_64.jar:$dir/lib/llvm-linux-x86_64.jar"
 runtime_classpath="$dir/runtime/out/classes"
 runtime_classpath="$runtime_classpath:$extra_cp"
 

--- a/jdk/stubs.cpp
+++ b/jdk/stubs.cpp
@@ -2,6 +2,7 @@
 // missing for various (usually unknown) reasons.
 #include <cstdio>
 #include <cstdlib>
+#include <execinfo.h>
 #include "jni.h"
 
 extern "C" {

--- a/runtime/native/jvm.cpp
+++ b/runtime/native/jvm.cpp
@@ -1570,4 +1570,9 @@ JVM_GetVersionInfo(JNIEnv* env, jvm_version_info* info, size_t info_size) {
   //    JvmIgnore("JVM_GetVersionInfo");
 }
 
+void
+JVM_GetClassTypeAnnotations(){
+    JvmUnimplemented("JVM_GetClassTypeAnnotations");
+}
+
 } // extern "C"

--- a/runtime/native/jvm.h
+++ b/runtime/native/jvm.h
@@ -646,4 +646,7 @@ typedef struct {
 void
 JVM_GetVersionInfo(JNIEnv* env, jvm_version_info* info, size_t info_size);
 
+void
+JVM_GetClassTypeAnnotations();
+
 } // extern "C"

--- a/tests/isolated/Makefile
+++ b/tests/isolated/Makefile
@@ -19,6 +19,11 @@ JDK_CLASSES := $(realpath $(JDK)/out/classes)
 JDK7 ?= /Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home/
 endif
 
+# Setup variables for travis CI
+ifdef TRAVIS
+ADDITIONAL_JLANGC_OPTIONS:=-compiler-classpath $(realpath $(BASE_DIR)/lib/llvm-linux-x86_64-Ubuntu12.04.jar)
+endif
+
 SRC := $(shell find * -name "*.java")
 
 CLASSES := $(SRC:.java=.class)
@@ -69,12 +74,12 @@ $(SOL): $(SRC)
 
 $(LL): $(SRC)
 	@echo "Compiling $(words $?) Java file(s) down to LLVM IR"
-	@$(BASE_DIR)/bin/jlangc -cp $(JDK_CLASSES) -assert $?
+	@$(BASE_DIR)/bin/jlangc $(ADDITIONAL_JLANGC_OPTIONS) -cp $(JDK_CLASSES) -assert $?
 	@touch $(LL)
 
 %.ll: %.java
 	@echo "Compiling file to LLVM IR"
-	@$(BASE_DIR)/bin/jlangc -cp $(JDK_CLASSES) -assert $?
+	@$(BASE_DIR)/bin/jlangc $(ADDITIONAL_JLANGC_OPTIONS) -cp $(JDK_CLASSES) -assert $?
 
 %.binary: %.ll
 	@echo "Creating binary for $<"


### PR DESCRIPTION
Adds a travis config to build JLang on both MacOS and linux, and run the tests on linux. Due to the new licensing of the oracle JDK7, the linux distro used is Ubuntu precise, which on travis still has the Oracle JDK7 pre-installed. MacOS does not, so running the tests does not work as expected. The travis file installs and/or builds the necessary components, and then builds JLang using its makefiles. The current LLVM jar in the repo does not support Ubuntu 12.04, so LLVM was rebuilt and packaged using the javacpp-presets project, and the jlangc driver was modified to support additional classpath options for running the compiler. The makefiles to build the project and run tests were then modified with the additional classpath only under the travis environment to maintain compatibility with currently working environments. This addresses issue #21.