### PR TITLE
remove trailing slash from url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/polyglot"]
 	path = lib/polyglot
-	url = https://github.com/polyglot-compiler/polyglot/
+	url = https://github.com/polyglot-compiler/polyglot
 	ignore = untracked
 [submodule "lib/javacpp-presets"]
 	path = lib/javacpp-presets


### PR DESCRIPTION
git repositories can not be cloned with a slash at the end