### PR TITLE
Implement thread interrupt and fix synchronization issues

### DIFF
--- a/compiler/src/jlang/extension/JLangClassDeclExt.java
+++ b/compiler/src/jlang/extension/JLangClassDeclExt.java
@@ -146,7 +146,7 @@ public class JLangClassDeclExt extends JLangExt {
                 		LLVMConstNull(v.utils.i8Ptr()) :
                 		v.utils.buildCastToBytePtr(v.dv.getDispatchVectorFor(ct)),
 
-                // Object size (Base Object Rep + all fields) in bytes, i32
+                // Object size (Base Object Rep + all fields) in bytes, i64
                 v.obj.sizeOf(ct),
 
                 // Boolean isInterface, jboolean (i8)

--- a/compiler/src/jlang/extension/JLangClassDeclExt.java
+++ b/compiler/src/jlang/extension/JLangClassDeclExt.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static jlang.extension.JLangSynchronizedExt.buildMonitorFunc;
+import static jlang.extension.JLangSynchronizedExt.buildMonitorFuncWithGlobalMutex;
 import static jlang.util.Constants.REGISTER_CLASS_FUNC;
 import static jlang.util.Constants.RUNTIME_ARRAY;
 import static org.bytedeco.javacpp.LLVM.*;
@@ -192,9 +193,7 @@ public class JLangClassDeclExt extends JLangExt {
 
         Runnable buildBody = () -> {
             // Synchronize the class loading function.
-            LLVMValueRef globalMutexPtr = v.utils.getGlobal(Constants.GLOBAL_MUTEX_OBJECT, v.utils.toLL(v.ts.Object()));
-            LLVMValueRef globalMutex = LLVMBuildLoad(v.builder, globalMutexPtr, "load.classLoad");
-            buildMonitorFunc(v, Constants.MONITOR_ENTER, globalMutex);
+            buildMonitorFuncWithGlobalMutex(v, Constants.MONITOR_ENTER);
 
             // Allocate and store a new java.lang.Class instance.
             // Note that we do not call any constructors for the allocated class objects.
@@ -252,7 +251,7 @@ public class JLangClassDeclExt extends JLangExt {
                 }
             }
 
-            buildMonitorFunc(v, Constants.MONITOR_EXIT, globalMutex);
+            buildMonitorFuncWithGlobalMutex(v, Constants.MONITOR_EXIT);
 
             // Return the loaded class.
             LLVMBuildRet(v.builder, clazz);

--- a/compiler/src/jlang/extension/JLangClassDeclExt.java
+++ b/compiler/src/jlang/extension/JLangClassDeclExt.java
@@ -130,6 +130,22 @@ public class JLangClassDeclExt extends JLangExt {
         		.map(intf -> v.utils.getClassObjectGlobal(intf))
         		.toArray(LLVMValueRef[]::new);
 
+        LLVMTypeRef classInfoType = v.utils.structType(
+                v.utils.i8Ptr(), // char* name
+                v.utils.ptrTypeRef(classType), // jclass*
+                v.utils.i8Ptr(),   // void*
+                v.utils.i64(), // obj_size
+                v.utils.i8() , // jboolean
+                v.utils.i32(),  // int32_t
+                v.utils.ptrTypeRef(v.utils.ptrTypeRef(classType)),     // jclass **
+                v.utils.i32(),      // int32_t
+                v.utils.ptrTypeRef(fieldInfoType),     // JavaFieldInfo*
+                v.utils.i32(),      // int32_t
+                v.utils.ptrTypeRef(staticFieldType),     // JavaStaticFieldInfo*
+                v.utils.i32(),      // int32_t
+                v.utils.ptrTypeRef(methodInfoType)      // JavaMethodInfo*
+        );
+
         // This layout must precisely mirror the layout defined in the runtime (class.cpp).
         LLVMValueRef classInfo = v.utils.buildConstStruct(
 
@@ -182,7 +198,7 @@ public class JLangClassDeclExt extends JLangExt {
 
         // Emit class info as a global variable.
         String classInfoMangled = v.mangler.classInfoGlobal(ct);
-        LLVMValueRef classInfoGlobal = v.utils.getGlobal(classInfoMangled, LLVMTypeOf(classInfo));
+        LLVMValueRef classInfoGlobal = v.utils.getGlobal(classInfoMangled, classInfoType);
         LLVMSetInitializer(classInfoGlobal, classInfo);
         LLVMSetGlobalConstant(classInfoGlobal, 1);
         LLVMSetLinkage(classInfoGlobal, LLVMPrivateLinkage);

--- a/compiler/src/jlang/extension/JLangStringLitExt.java
+++ b/compiler/src/jlang/extension/JLangStringLitExt.java
@@ -61,8 +61,9 @@ public class JLangStringLitExt extends JLangExt {
         LLVMSetInitializer(stringLit, charArray);
 
         LLVMValueRef dvString = v.dv.getDispatchVectorFor(v.ts.String());
+
         LLVMValueRef[] stringLitBody =
-                Stream.of(dvString, sync_vars, LLVMConstBitCast(stringLit, v.utils.toLL(arrayType)), LLVMConstInt(v.utils.intType(16), 0, 0))
+                Stream.of(dvString, sync_vars, LLVMConstBitCast(stringLit, v.utils.toLL(arrayType)))
                         .toArray(LLVMValueRef[]::new);
 
         LLVMValueRef string = v.utils.buildConstStruct(stringLitBody);

--- a/compiler/src/jlang/extension/JLangSynchronizedExt.java
+++ b/compiler/src/jlang/extension/JLangSynchronizedExt.java
@@ -3,7 +3,9 @@
 package jlang.extension;
 
 import jlang.ast.JLangExt;
+import jlang.util.Constants;
 import jlang.visit.LLVMTranslator;
+import org.bytedeco.javacpp.LLVM.LLVMBasicBlockRef;
 import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
 import org.bytedeco.javacpp.LLVM.LLVMValueRef;
 import polyglot.ast.Node;
@@ -22,6 +24,15 @@ public class JLangSynchronizedExt extends JLangExt {
             printedWarning = true;
         }
         return super.leaveTranslateLLVM(v);
+    }
+
+    public static void buildMonitorFuncWithGlobalMutex(LLVMTranslator v, String op) {
+        LLVMTypeRef getGlobalMutexFuncType = v.utils.functionType(
+                v.utils.toLL(v.ts.Object())
+        );
+        LLVMValueRef getGlobalMutexFunc = v.utils.getFunction(Constants.GET_GLOBAL_MUTEX_OBJECT, getGlobalMutexFuncType);
+        LLVMValueRef globalMutex = v.utils.buildFunCall(getGlobalMutexFunc);
+        buildMonitorFunc(v, op, globalMutex);
     }
 
     public static void buildMonitorFunc(LLVMTranslator v, String op, LLVMValueRef syncObj) {

--- a/compiler/src/jlang/util/Constants.java
+++ b/compiler/src/jlang/util/Constants.java
@@ -35,7 +35,7 @@ public class Constants {
     public static final String RESUME_UNWIND_EXCEPTION = "_Unwind_Resume";
     public static final String MONITOR_ENTER = "jni_MonitorEnter";
     public static final String MONITOR_EXIT = "jni_MonitorExit";
-    public static final String GLOBAL_MUTEX_OBJECT = "Polyglot_native_GlobalMutexObject";
+    public static final String GET_GLOBAL_MUTEX_OBJECT = "getGlobalMutexObject";
   
     public static final Set<String> NON_INVOKE_FUNCTIONS = new HashSet<>(CollectionUtil.list(
             CALLOC, CREATE_EXCEPTION, EXTRACT_EXCEPTION

--- a/compiler/src/jlang/util/LLVMUtils.java
+++ b/compiler/src/jlang/util/LLVMUtils.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static jlang.extension.JLangSynchronizedExt.buildMonitorFunc;
+import static jlang.extension.JLangSynchronizedExt.buildMonitorFuncWithGlobalMutex;
 import static org.bytedeco.javacpp.LLVM.*;
 
 /**
@@ -805,9 +806,7 @@ public class LLVMUtils {
     /** Emits a check to ensure that the given class has been loaded by the runtime. */
     public void buildClassLoadCheck(ClassType ct) {
         // Synchronize the class loading function.
-        LLVMValueRef globalMutexPtr = v.utils.getGlobal(Constants.GLOBAL_MUTEX_OBJECT, v.utils.toLL(v.ts.Object()));
-        LLVMValueRef globalMutex = LLVMBuildLoad(v.builder, globalMutexPtr, "load.classLoad");
-        buildMonitorFunc(v, Constants.MONITOR_ENTER, globalMutex);
+        buildMonitorFuncWithGlobalMutex(v, Constants.MONITOR_ENTER);
 
         LLVMBasicBlockRef loadClass = v.utils.buildBlock("load.class");
         LLVMBasicBlockRef end = v.utils.buildBlock("continue");
@@ -827,7 +826,7 @@ public class LLVMUtils {
 
         LLVMPositionBuilderAtEnd(v.builder, end);
 
-        buildMonitorFunc(v, Constants.MONITOR_EXIT, globalMutex);
+        buildMonitorFuncWithGlobalMutex(v, Constants.MONITOR_EXIT);
     }
 
     /**

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -23,7 +23,7 @@ JAVA_FLAGS := \
 
 NATIVE_FLAGS := \
 	-g -fPIC -std=c++14 -Inative $(JNI_INCLUDES) \
-	-Wall -MMD -pthread $(MACOS_FLAGS)
+	-Wall -MMD -pthread $(MACOS_FLAGS) -D_GLIBCXX_DEBUG
 
 all: classes $(LIBJVM)
 

--- a/runtime/linux_version.map
+++ b/runtime/linux_version.map
@@ -19,6 +19,7 @@ SUNWprivate_1.1 {
 		__createInterfaceTables;
 		__java_personality_v0;
 		__GC_malloc;
+        getGlobalMutexObject;
         local:
 	        *;
 };

--- a/runtime/native/class.cpp
+++ b/runtime/native/class.cpp
@@ -684,3 +684,31 @@ jclass LoadJavaClassFromLib(const char *name) {
         return NULL;
     }
 }
+
+/**
+ * Find a class with the given name. If it is not loaded, the class loading
+ * function will be invoked. The class name is in the format java.lang.Class
+ */
+jclass FindClass(const char *name) {
+    Monitor::Instance().enter(nullptr);
+    jclass clazz = GetJavaClassFromName(name);
+    if (clazz == nullptr) {
+        clazz = LoadJavaClassFromLib(name);
+    }
+    Monitor::Instance().exit(nullptr);
+    return clazz;
+}
+
+/**
+ * Find a class with the given name. If it is not loaded, the class loading
+ * function will be invoked. The class name is in the format java/lang/Class
+ */
+jclass FindClassFromPathName(const char *name) {
+    Monitor::Instance().enter(nullptr);
+    jclass clazz = GetJavaClassFromPathName(name);
+    if (clazz == nullptr) {
+        clazz = LoadJavaClassFromLib(name);
+    }
+    Monitor::Instance().exit(nullptr);
+    return clazz;
+}

--- a/runtime/native/class.cpp
+++ b/runtime/native/class.cpp
@@ -690,12 +690,11 @@ jclass LoadJavaClassFromLib(const char *name) {
  * function will be invoked. The class name is in the format java.lang.Class
  */
 jclass FindClass(const char *name) {
-    Monitor::Instance().enter(nullptr);
+    ScopedLock scopedLock(Monitor::Instance().globalMutex());
     jclass clazz = GetJavaClassFromName(name);
     if (clazz == nullptr) {
         clazz = LoadJavaClassFromLib(name);
     }
-    Monitor::Instance().exit(nullptr);
     return clazz;
 }
 
@@ -704,11 +703,10 @@ jclass FindClass(const char *name) {
  * function will be invoked. The class name is in the format java/lang/Class
  */
 jclass FindClassFromPathName(const char *name) {
-    Monitor::Instance().enter(nullptr);
+    ScopedLock scopedLock(Monitor::Instance().globalMutex());
     jclass clazz = GetJavaClassFromPathName(name);
     if (clazz == nullptr) {
         clazz = LoadJavaClassFromLib(name);
     }
-    Monitor::Instance().exit(nullptr);
     return clazz;
 }

--- a/runtime/native/class.h
+++ b/runtime/native/class.h
@@ -64,7 +64,7 @@ struct JavaClassInfo {
     char *name;
     jclass *super_ptr;
     void *cdv;        // is a DispatchVector*
-    int32_t obj_size; // for array, it does not include data_size
+    int64_t obj_size; // for array, it does not include data_size
 
     jboolean isIntf;
 

--- a/runtime/native/class.h
+++ b/runtime/native/class.h
@@ -118,6 +118,10 @@ GetJavaStaticMethodInfo(jclass cls, const char *name, const char *sig);
 
 jclass LoadJavaClassFromLib(const char *name);
 
+jclass FindClass(const char *name);
+
+jclass FindClassFromPathName(const char *name);
+
 bool isArrayClassName(const char *name);
 
 bool isArrayClass(jclass cls);

--- a/runtime/native/debug.cpp
+++ b/runtime/native/debug.cpp
@@ -1,0 +1,3 @@
+#include <string>
+
+std::string make_string(const char *x) { return x; }

--- a/runtime/native/exception.cpp
+++ b/runtime/native/exception.cpp
@@ -65,6 +65,7 @@ void Polyglot_jlang_runtime_Exceptions_throwNewThrowable__Ljava_lang_Class_2Ljav
     jclass clazz, jstring str);
 void Polyglot_jlang_runtime_Exceptions_throwThrowable__Ljava_lang_Throwable_2(
     jthrowable obj);
+void Polyglot_jlang_runtime_Exceptions_throwInterruptedException__();
 // A distinct integer identifying our own exceptions.
 const uint64_t javaExceptionClass = 8101813523428701805ll;
 
@@ -519,4 +520,8 @@ void throwNewThrowable(JNIEnv *env, jclass clazz, const char *msg) {
 void throwThrowable(JNIEnv *env, jthrowable obj) {
     Polyglot_jlang_runtime_Exceptions_throwThrowable__Ljava_lang_Throwable_2(
         obj);
+}
+
+void throwInterruptedException(JNIEnv *env) {
+    Polyglot_jlang_runtime_Exceptions_throwInterruptedException__();
 }

--- a/runtime/native/exception.h
+++ b/runtime/native/exception.h
@@ -9,6 +9,7 @@
 void throwClassNotFoundException(JNIEnv *env, const char *name);
 void throwNewThrowable(JNIEnv *env, jclass clazz, const char *msg);
 void throwThrowable(JNIEnv *env, jthrowable obj);
+void throwInterruptedException(JNIEnv *env);
 
 extern "C" {
 

--- a/runtime/native/factory.cpp
+++ b/runtime/native/factory.cpp
@@ -4,6 +4,7 @@
 
 #include "class.h"
 #include "rep.h"
+#include "monitor.h"
 
 #include <jni.h>
 #include <string.h>
@@ -66,6 +67,8 @@ jstring CreateJavaString(jcharArray chars) {
 }
 
 jobject CreateJavaObject(jclass clazz) {
+    ScopedLock lock(Monitor::Instance().globalMutex());
+
     auto info = GetJavaClassInfo(clazz);
     // TODO set exception (class is interface or abstract)
     if (info == NULL || info->cdv == NULL) {
@@ -81,6 +84,8 @@ jobject CreateJavaObject(jclass clazz) {
 
 jobject CloneJavaObject(jobject obj) {
     // TODO set exception if class is not cloneable
+    ScopedLock lock(Monitor::Instance().globalMutex());
+
     auto objRep = Unwrap(obj);
     auto cdv = objRep->Cdv();
     auto cls = cdv->Class()->Wrap();

--- a/runtime/native/init.cpp
+++ b/runtime/native/init.cpp
@@ -11,13 +11,13 @@ void Polyglot_java_lang_System_initializeSystemClass__();
 
 void InitializeMainThread() {
     // initialize classes
-    LoadJavaClassFromLib("java.lang.String");
-    LoadJavaClassFromLib("java.lang.System");
-    LoadJavaClassFromLib("java.lang.Thread");
-    LoadJavaClassFromLib("java.lang.ThreadGroup");
-    LoadJavaClassFromLib("java.lang.reflect.Method");
-    LoadJavaClassFromLib("java.lang.ref.Finalizer");
-    LoadJavaClassFromLib("java.lang.Class");
+    FindClass("java.lang.String");
+    FindClass("java.lang.System");
+    FindClass("java.lang.Thread");
+    FindClass("java.lang.ThreadGroup");
+    FindClass("java.lang.reflect.Method");
+    FindClass("java.lang.ref.Finalizer");
+    FindClass("java.lang.Class");
 
     // setup currentThread for main thread
     currentThread = GetMainThread();

--- a/runtime/native/jni.cpp
+++ b/runtime/native/jni.cpp
@@ -33,13 +33,7 @@ jclass jni_FindClass(JNIEnv *env, const char *name) {
     // files
     if (name == NULL)
         return NULL;
-    jclass clazz = GetJavaClassFromPathName(name);
-    if (clazz == NULL) {
-        ScopedLock lock(Monitor::Instance().globalMutex());
-        return LoadJavaClassFromLib(name);
-    } else {
-        return clazz;
-    }
+    return FindClassFromPathName(name);
 }
 
 jmethodID jni_FromReflectedMethod(JNIEnv *env, jobject method) {

--- a/runtime/native/jvm.cpp
+++ b/runtime/native/jvm.cpp
@@ -19,7 +19,6 @@
 #include <cstring>
 #include <dlfcn.h>
 #include <fcntl.h>
-#include <pthread.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -28,6 +27,11 @@
 #include <unistd.h>
 #include <unordered_map>
 #include <vector>
+#include <pthread.h>
+
+#define GC_THREADS
+#include <gc.h>
+#undef GC_THREADS
 
 [[noreturn]] static void JvmUnimplemented(const char *name) {
     fprintf(stderr,
@@ -733,10 +737,15 @@ jobjectArray JVM_GetClassDeclaredMethods(JNIEnv *env, jclass ofClass,
             }
 
             jstring signature = env->NewStringUTF(methods[i].sig);
+
+            // TODO: use the correct checkedExceptions
+            jobjectArray checkedExceptions = (jobjectArray)create1DArray(
+                "[Ljava.lang.Class;", 0);
+            
             // TODO need to get the proper values
             // call the method constructor
             METHOD_INIT_FUNC(newMethod, ofClass, nameString, paramTypes,
-                             returnType, NULL, modifiers, slot, NULL, NULL,
+                             returnType, checkedExceptions, modifiers, slot, NULL, NULL,
                              NULL, NULL);
 
             JVM_SetArrayElement(env, ret, i, newMethod);

--- a/runtime/native/jvm.cpp
+++ b/runtime/native/jvm.cpp
@@ -699,7 +699,7 @@ jobjectArray JVM_GetClassDeclaredMethods(JNIEnv *env, jclass ofClass,
             return (jobjectArray)create1DArray(methodArrType, 0);
         }
 
-        jclass MethodClass = env->FindClass("java.lang.reflect.Method");
+        jclass MethodClass = FindClass("java.lang.reflect.Method");
 
         // dw475 TODO take into account publiconly argument
 
@@ -719,9 +719,9 @@ jobjectArray JVM_GetClassDeclaredMethods(JNIEnv *env, jclass ofClass,
 
             if (methods[i].returnType == nullptr) {
                 methods[i].returnType =
-                    new jclass(GetJavaClassFromName(classNames.back().c_str()));
+                    new jclass(FindClass(classNames.back().c_str()));
             } else if (*methods[i].returnType == NULL) {
-                LoadJavaClassFromLib(classNames.back().c_str());
+                FindClass(classNames.back().c_str());
             }
             jclass returnType = *methods[i].returnType;
 
@@ -730,9 +730,9 @@ jobjectArray JVM_GetClassDeclaredMethods(JNIEnv *env, jclass ofClass,
             for (int k = 0; k < methods[i].numArgTypes; k++) {
                 if (methods[i].argTypes[k] == nullptr) {
                     methods[i].argTypes[k] =
-                        new jclass(GetJavaClassFromName(classNames[k].c_str()));
+                        new jclass(FindClass(classNames[k].c_str()));
                 } else if (*methods[i].argTypes[k] == nullptr) {
-                    LoadJavaClassFromLib(classNames[k].c_str());
+                    FindClass(classNames[k].c_str());
                 }
                 JVM_SetArrayElement(env, paramTypes, k,
                                     *methods[i].argTypes[k]);
@@ -784,7 +784,7 @@ jobjectArray JVM_GetClassDeclaredFields(JNIEnv *env, jclass ofClass,
             return (jobjectArray)create1DArray(fieldArrType, 0);
         }
 
-        jclass FieldsClass = env->FindClass("java.lang.reflect.Field");
+        jclass FieldsClass = FindClass("java.lang.reflect.Field");
 
         // dw475 TODO take into account publiconly argument
 
@@ -826,13 +826,12 @@ jobjectArray JVM_GetClassDeclaredFields(JNIEnv *env, jclass ofClass,
                     printf("WARNING: Non-Array field has null type_ptr\n");
                 }
                 std::string className = SigToClassName(signature);
-                *typePtrPtr =
-                    new jclass(GetJavaClassFromName(className.c_str()));
+                *typePtrPtr = new jclass(FindClass(className.c_str()));
             } else if (**typePtrPtr == nullptr) {
                 // The typeClass that type_ptr points to has not initialized
                 // yet. Call the class loading function to load it.
                 std::string className = SigToClassName(signature);
-                LoadJavaClassFromLib(className.c_str());
+                FindClass(className.c_str());
                 if (**typePtrPtr == nullptr) {
                     printf("WARNING: Class is not loaded correctly\n");
                 }

--- a/runtime/native/jvm.cpp
+++ b/runtime/native/jvm.cpp
@@ -101,6 +101,8 @@ template <> struct hash<HashableShortArray> {
 std::unordered_map<HashableShortArray, jstring> InternedStrings;
 
 jstring internJString(jstring str) {
+    ScopedLock lock(Monitor::Instance().globalMutex());
+
     HashableShortArray *h =
         (HashableShortArray *)malloc(sizeof(HashableShortArray));
     h->len = (int)Unwrap(str)->Chars()->Length();

--- a/runtime/native/monitor.cpp
+++ b/runtime/native/monitor.cpp
@@ -48,17 +48,13 @@ static void initSyncVars(jobject obj) {
 // A fake object to hold the sync_var of class loading function.
 // The class loading code could utilize this global object to ensure that
 // every class is only initilized by one thread once.
-JObjectRep __Polyglot_native_GlobalMutexObject;
-
-static jobject getGlobalMutexObject() {
+extern "C" jobject getGlobalMutexObject() {
+    static JObjectRep __Polyglot_native_GlobalMutexObject;
     if (__Polyglot_native_GlobalMutexObject.SyncVars() == nullptr) {
         initSyncVars(__Polyglot_native_GlobalMutexObject.Wrap());
     }
     return __Polyglot_native_GlobalMutexObject.Wrap();
 }
-
-jobject Polyglot_native_GlobalMutexObject = getGlobalMutexObject();
-
 
 Monitor::Monitor() {
     if (pthread_mutex_init(&mutex, nullptr) != 0) {

--- a/runtime/native/monitor.cpp
+++ b/runtime/native/monitor.cpp
@@ -7,8 +7,8 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <pthread.h>
 #include <unordered_map>
+#include <pthread.h>
 
 #define GC_THREADS
 #include <gc.h>

--- a/runtime/native/monitor.h
+++ b/runtime/native/monitor.h
@@ -7,6 +7,10 @@
 #include <jni.h>
 #include <pthread.h>
 
+#define GC_THREADS
+#include <gc.h>
+#undef GC_THREADS
+
 class Monitor {
   public:
     Monitor(const Monitor &monitor) = delete;

--- a/runtime/native/native.cpp
+++ b/runtime/native/native.cpp
@@ -1,8 +1,11 @@
 // Copyright (C) 2018 Cornell University
 
+#include "native.h"
+
 #include "class.h"
 #include "jni.h"
 #include "stack_trace.h"
+
 #include <cstdlib>
 #include <dlfcn.h>
 #include <string>
@@ -14,7 +17,6 @@
 #include <gc.h>
 #undef GC_THREADS
 
-#include "native.h"
 
 static constexpr bool kDebug = false;
 

--- a/runtime/native/rep.h
+++ b/runtime/native/rep.h
@@ -10,10 +10,15 @@
 #pragma once
 
 #include "interface.h"
+
 #include <cinttypes>
 #include <jni.h>
 #include <type_traits>
 #include <pthread.h>
+
+#define GC_THREADS
+#include <gc.h>
+#undef GC_THREADS
 
 // Ensure that our C++ representations are POD types,
 // i.e., that they have the layout we'd expect from a C struct.

--- a/runtime/native/threads.cpp
+++ b/runtime/native/threads.cpp
@@ -21,7 +21,7 @@ jobject GetMainThread() {
     }
 
     // create JavaGroup object associated with main Thread.
-    auto thread_group_clazz = LoadJavaClassFromLib("java.lang.ThreadGroup");
+    auto thread_group_clazz = FindClass("java.lang.ThreadGroup");
     jobject mainThreadGroup = CreateJavaObject(thread_group_clazz);
     CallJavaInstanceMethod<jobject>(mainThreadGroup, "<init>", "()V", nullptr);
 
@@ -37,7 +37,7 @@ jobject GetMainThread() {
     jstring mainStr = CreateJavaString(mainCharArray);
 
     // create main Thread object.
-    auto thread_clazz = GetJavaClassFromName("java.lang.Thread");
+    auto thread_clazz = FindClass("java.lang.Thread");
     mainThread = CreateJavaObject(thread_clazz);
     const jobject mainThreadArgs[] = {mainThreadGroup, mainStr};
     CallJavaInstanceMethod<jobject>(

--- a/runtime/native/threads.h
+++ b/runtime/native/threads.h
@@ -2,8 +2,12 @@
 
 #include <functional>
 #include <jvm.h>
-#include <pthread.h>
 #include <unordered_map>
+#include <pthread.h>
+
+#define GC_THREADS
+#include <gc.h>
+#undef GC_THREADS
 
 extern thread_local jobject currentThread;
 

--- a/runtime/native/threads.h
+++ b/runtime/native/threads.h
@@ -10,6 +10,7 @@ extern thread_local jobject currentThread;
 struct NativeThread {
     pthread_t tid;
     bool threadStatus;
+    bool interrupted;
 };
 
 class Threads {

--- a/runtime/src/jlang/runtime/Exceptions.java
+++ b/runtime/src/jlang/runtime/Exceptions.java
@@ -13,4 +13,5 @@ class Exceptions {
     static void throwThrowable(Throwable t) throws Throwable {
 	throw t;
     }
+    static void throwInterruptedException() throws InterruptedException { throw new InterruptedException(); }
 }

--- a/tests/isolated/ConcurrentReflection.java
+++ b/tests/isolated/ConcurrentReflection.java
@@ -132,50 +132,6 @@ public class ConcurrentReflection {
                 output.add(fld.getModifiers());
                 output.add(fld.getType());
                 output.add(fld.get(aaa));
-                // TODO fix something with generics
-                // output.add(fld.getGenericType());
-
-                if (fld.getName().equals("a")) {
-                    fld.setInt(aaa, 123412);
-                } else if (fld.getName().equals("bb")) {
-                    fld.setBoolean(aaa, true);
-                } else if (fld.getName().equals("cc")) {
-                    fld.setShort(aaa, new Short((short)17));
-                    fld.set(aaa, new Short((short)34));
-                } else if (fld.getName().equals("ff")) {
-                    fld.setFloat(aaa, 0.3432f);
-                } else if (fld.getName().equals("d")) {
-                    fld.set(aaa, new Double(1234544.92));
-                } else if (fld.getName().equals("j")) {
-                    fld.setByte(aaa, (byte) 11);
-                } else if (fld.getName().equals("ll")) {
-                    fld.setLong(aaa, 12998769931L);
-                } else if (fld.getName().equals("ch")) {
-                    fld.setChar(aaa, 'h');
-                }
-
-                // should work with static arguments as well
-                if (fld.getName().equals("b")) {
-                    fld.set(aaa, 5533);
-                } else if (fld.getName().equals("ss")) {
-                    fld.set(aaa, "ABCD");
-                } else if (fld.getName().equals("ii")) {
-                    fld.setInt(aaa, 88991);
-                } else if (fld.getName().equals("sb")) {
-                    fld.setBoolean(aaa, true);
-                } else if (fld.getName().equals("sc")) {
-                    fld.setChar(aaa, 'o');
-                } else if (fld.getName().equals("sby")) {
-                    fld.setByte(aaa, (byte) 55);
-                } else if (fld.getName().equals("ssh")) {
-                    fld.setShort(aaa, (short) 1351);
-                } else if (fld.getName().equals("sf")) {
-                    fld.setFloat(aaa, 998.43211f);
-                } else if (fld.getName().equals("sd")) {
-                    fld.setDouble(aaa, 10985373.12312414);
-                } else if (fld.getName().equals("sl")) {
-                    fld.setLong(aaa, 1L);
-                }
             }
 
             output.add(aaa.a);
@@ -240,12 +196,10 @@ public class ConcurrentReflection {
         @Override
         public void run() {
             try {
-                for (int i = 0; i < 5; i++) {
-                    ClassReflection.run(output);
-                    MethodReflection.run(output);
-                    FieldReflection.run(output);
-                    PrimitiveReflection.run(output);
-                }
+                ClassReflection.run(output);
+                MethodReflection.run(output);
+                FieldReflection.run(output);
+                PrimitiveReflection.run(output);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/tests/isolated/InterruptTest.java
+++ b/tests/isolated/InterruptTest.java
@@ -1,0 +1,37 @@
+public class InterruptTest {
+    public static void main(String args[]) {
+        Thread current = Thread.currentThread();
+        System.out.println(current.isInterrupted());
+        current.interrupt();
+        System.out.println(current.isInterrupted());
+        System.out.println(current.isInterrupted());
+        System.out.println(Thread.interrupted());
+        System.out.println(current.isInterrupted());
+        current.interrupt();
+        synchronized (current) {
+            try {
+                current.wait(1);
+                System.out.println("no");
+            } catch (InterruptedException e) {
+                System.out.println(e.getClass());
+            }
+        }
+        synchronized (current) {
+            try {
+                current.wait(1);
+                System.out.println("yes");
+            } catch (InterruptedException e) {
+                System.out.println(e.getClass());
+            }
+        }
+        current.interrupt();
+        synchronized (current) {
+            try {
+                current.join();
+                System.out.println("yes");
+            } catch (InterruptedException e) {
+                System.out.println(e.getClass());
+            }
+        }
+    }
+}

--- a/tests/isolated/ReflectionMemoryTest.java
+++ b/tests/isolated/ReflectionMemoryTest.java
@@ -1,0 +1,19 @@
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class ReflectionMemoryTest {
+    static boolean b;
+
+    public static void main(String[] args) {
+        ReflectionMemoryTest s = new ReflectionMemoryTest();
+        Class cls = s.getClass();
+        Field[] fields = cls.getDeclaredFields();
+        Method[] methods = cls.getDeclaredMethods();
+        System.out.println(fields.length);
+        for (int i = 0; i < 100000; i++) {
+            System.out.println(fields[0].getType());
+            System.out.println(methods[0].getReturnType());
+            System.out.println(i);
+        }
+    }
+}

--- a/tests/isolated/expected_fails
+++ b/tests/isolated/expected_fails
@@ -1,1 +1,2 @@
 ArrayReflection
+ReflectionMemoryTest


### PR DESCRIPTION
This PR implemented thread.interrupt in commit ce1e331. It also refactored some existing runtime code and fix several synchronization issues. Now, the reflection concurrency tests also pass. 

However, there are still two problems that might happen in reflection concurrency tests if we run a longer ConcurrentReflectionTest (increase the number of iteration), but neither of them are due to multithreading or concurrency.

The first one is in method reflection. If we run a method invocation through reflection lots of times, JDK will switch to a different `MethodAccessor` which calls several unimplemented JVM methods (`DefineClass`...). I believe this is Java's JIT behavior. To avoid this, either we need to patch the JDK to prevent the switching from happening or we have to implement those methods in JVM.

The second one happens in both method reflection and field reflection. If we keep invoking `field.getType()` or `method.getReturnType()` for thousands of times, a segfault will be thrown. It happened nondeterministically. I believe either we are not correctly allocating the memory using GC or we somehow overwrite objects in runtime. I wrote `ReflectionMemoryTest.java` to reproduce this problem.